### PR TITLE
request singleton and instance methods explicitly

### DIFF
--- a/lib/mirrors/package_inference/class_to_file_resolver.rb
+++ b/lib/mirrors/package_inference/class_to_file_resolver.rb
@@ -27,7 +27,7 @@ module Mirrors
       end
 
       def try_fast(cm, demodulized_name)
-        cm.methods.each do |mm|
+        cm.instance_methods.each do |mm|
           file = mm.file
           next unless file
 
@@ -39,7 +39,7 @@ module Mirrors
       end
 
       def try_slow(cm)
-        defined_directly_on_class = cm.methods
+        defined_directly_on_class = cm.instance_methods
           .select do |mm|
             # as a mostly-useful heuristic, we just eliminate everything that was
             # defined using a template eval or define_method.

--- a/test/fixtures/class.rb
+++ b/test/fixtures/class.rb
@@ -12,18 +12,27 @@ class ClassFixture
   end
   include ClassFixtureModule
 
-  attr_accessor :b
-  def a
-    @a = 1
-    @@cvb = 1
-  end
-
   @@cva = 1
   @civa = 1
 
-  def self.b
-    @@cvc = 1
-    @civb = 1
+  public def inst_pub
+  end
+
+  protected def inst_prot
+  end
+
+  private def inst_priv
+  end
+
+  class << self
+    public def singleton_pub
+    end
+
+    protected def singleton_prot
+    end
+
+    private def singleton_priv
+    end
   end
 end
 

--- a/test/mirrors/class_mirror_test.rb
+++ b/test/mirrors/class_mirror_test.rb
@@ -51,12 +51,25 @@ module Mirrors
     end
 
     def test_instance_methods
-      assert_equal(ClassFixture.instance_methods(false).size, @m.methods.size)
+      ims = @m.instance_methods
+      assert_equal(%i(inst_prot inst_pub inst_priv), ims.map(&:name))
     end
 
     def test_instance_method
-      n = ClassFixture.instance_methods.first
-      assert(@m.method(n).mirrors?(ClassFixture.instance_method(n)))
+      meth = @m.instance_method(:inst_prot)
+      assert_equal(:inst_prot, meth.name)
+      assert_equal(:protected, meth.visibility)
+    end
+
+    def test_singleton_methods
+      sms = @m.singleton_methods
+      assert_equal(%i(singleton_prot singleton_pub singleton_priv), sms.map(&:name))
+    end
+
+    def test_singleton_method
+      meth = @m.singleton_method(:singleton_priv)
+      assert_equal(:singleton_priv, meth.name)
+      assert_equal(:private, meth.visibility)
     end
 
     def test_ancestors

--- a/test/mirrors/iseq_visitor_test.rb
+++ b/test/mirrors/iseq_visitor_test.rb
@@ -24,7 +24,7 @@ module Mirrors
       largest_method = nil
 
       Mirrors.classes.each do |klass|
-        klass.methods.each do |meth|
+        klass.instance_methods.each do |meth|
           visitor = CountingVisitor.new
           visitor.call(meth.native_code)
           bytecode_count += visitor.count

--- a/test/mirrors/method_mirror_test.rb
+++ b/test/mirrors/method_mirror_test.rb
@@ -29,7 +29,7 @@ module Mirrors
     end
 
     def test_public_method
-      m = @cm.method(:method_p_public)
+      m = @cm.instance_method(:method_p_public)
       assert(m.public?)
       refute(m.protected?)
       refute(m.private?)
@@ -37,7 +37,7 @@ module Mirrors
     end
 
     def test_protected_method
-      m = @cm.method(:method_p_protected)
+      m = @cm.instance_method(:method_p_protected)
       refute(m.public?)
       assert(m.protected?)
       refute(m.private?)
@@ -45,7 +45,7 @@ module Mirrors
     end
 
     def test_private_method
-      m = @cm.method(:method_p_private)
+      m = @cm.instance_method(:method_p_private)
       refute(m.public?)
       refute(m.protected?)
       assert(m.private?)

--- a/test/mirrors/references_visitor_test.rb
+++ b/test/mirrors/references_visitor_test.rb
@@ -12,7 +12,7 @@ module Mirrors
     end
 
     def test_victim_class
-      method = Mirrors.reflect(Victim).methods.first
+      method = Mirrors.reflect(Victim).instance_methods.first
       refs = method.references
       assert_equal(4, refs.size)
       c1 = Marker.new(type: Marker::TYPE_CLASS_REFERENCE, message: :Kernel, file: __FILE__, line: 10)


### PR DESCRIPTION
cc @graemej 

Previously, `ClassMirror#methods` returned instance methods (i.e. `Class#instance_methods`) and provided no API to get at singleton methods (i.e. `Class#methods`).

I think Ruby's API for this is confusing (`instance_methods` + `methods`).

What I've done here is made the new API `instance_methods` + ~~`singleton_methods`~~ `class_methods`, so for example:

```ruby
class A
  def self.foo
  end
  def bar
  end
end

Mirrors.reflect(A).instance_methods #=> [#<MM:bar>]
Mirrors.reflect(A).class_methods #=> [#<MM:foo>]
Mirrors.reflect(A).methods #=> !!!NoMethodError!!!
```

I've also banned `#methods` and `#method` on `ClassMirror` to prevent confusion, even though it *could* be used to return the methods supported on `ClassMirror` itself. I've renamed them to `#__method{,s}` for this purpose.

Thoughts?