### PR TITLE
Don't try to intern MethodMirrors that are defined on Objects

### DIFF
--- a/lib/mirrors.rb
+++ b/lib/mirrors.rb
@@ -193,7 +193,10 @@ module Mirrors
 
     def reflect_method(obj)
       mirror = MethodMirror.new(obj)
-      mirror.defining_class.intern_method_mirror(mirror)
+      if mirror.defining_class.respond_to?(:intern_method_mirror)
+        mirror = mirror.defining_class.intern_method_mirror(mirror)
+      end
+      mirror
     end
 
     def reflect_class(obj)

--- a/test/fixtures/method.rb
+++ b/test/fixtures/method.rb
@@ -50,3 +50,24 @@ class SuperMethodSpecFixture < MethodSpecFixture
   def not_inherited
   end
 end
+
+class HelperModule < Module
+  def initialize(something)
+    @something = something
+  end
+
+  def to_s
+    "Helper for #{@something}"
+  end
+end
+
+DYNAMIC_INCLUDE = HelperModule.new("fixture")
+
+class ObjectIncludeFixture
+  include DYNAMIC_INCLUDE
+end
+
+DYNAMIC_INCLUDE.class_eval do
+  def method_from_dynamic_include
+  end
+end

--- a/test/mirrors/method_mirror_test.rb
+++ b/test/mirrors/method_mirror_test.rb
@@ -114,6 +114,12 @@ module Mirrors
       assert_equal(:private, m.visibility)
     end
 
+    def test_method_included_from_instance
+      method_mirror = Mirrors.reflect(ObjectIncludeFixture.new.method(:method_from_dynamic_include))
+      assert(method_mirror.public?)
+      assert_equal(method_mirror.defining_class.reflectee, DYNAMIC_INCLUDE)
+    end
+
     private
 
     def method_b(a, b = 1, bb = 2, *args, &block)


### PR DESCRIPTION
@burke this hit us for some stuff defined by StateMachine helper modules in Core ... are we ok if mirror.defining_class is an ObjectMirror who's methods aren't interned (since that seems wasteful?)